### PR TITLE
feat: add CodeArts Check action with report publishing

### DIFF
--- a/.github/workflows/codearts-check.yml
+++ b/.github/workflows/codearts-check.yml
@@ -1,0 +1,38 @@
+name: CodeArts Check Analyze
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run CodeArts Check and publish report
+        uses: ./
+        with:
+          codearts_endpoint: ${{ secrets.CODEARTS_ENDPOINT }}
+          codearts_token: ${{ secrets.CODEARTS_TOKEN }}
+          # If CODEARTS_TOKEN is not configured, set IAM secrets below:
+          # iam_endpoint: https://iam.myhuaweicloud.com
+          # iam_username: ${{ secrets.HW_IAM_USERNAME }}
+          # iam_password: ${{ secrets.HW_IAM_PASSWORD }}
+          # iam_domain_name: ${{ secrets.HW_IAM_DOMAIN_NAME }}
+          # iam_project_name: ${{ secrets.HW_IAM_PROJECT_NAME }}
+          project_id: ${{ secrets.CODEARTS_PROJECT_ID }}
+          project_name: ${{ secrets.CODEARTS_PROJECT_NAME }}
+          repo_url: ${{ secrets.CODEARTS_REPO_URL }}
+          branch: main
+          task_name: maven-demo-main-check
+          repo_type: GitHub
+          rule_language: Java
+          report_repo: Jo-joker/maven-demo
+          report_dir: analyze
+          github_token: ${{ secrets.REPORT_REPO_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,100 @@
-# GitHubAction
+# CodeArts Check Report Action
+
+GitHub Action for Huawei Cloud **CodeArts Check**:
+
+1. Create a CodeArts Check task.
+2. Run the created task immediately.
+3. Poll until execution completes.
+4. Fetch summary and defect details.
+5. Generate a Markdown analysis report.
+6. Upload the report to a target GitHub repository directory (default: `Jo-joker/maven-demo/analyze`).
+
+## Inputs
+
+### CodeArts / IAM
+
+- `codearts_endpoint` (required): CodeArts Check endpoint, for example `https://codeartscheck.cn-north-4.myhuaweicloud.com`
+- `codearts_token` (optional): `X-Auth-Token` for CodeArts Check APIs
+- `iam_endpoint` (optional, default: `https://iam.myhuaweicloud.com`)
+- `iam_username` (optional, required when `codearts_token` is empty)
+- `iam_password` (optional, required when `codearts_token` is empty)
+- `iam_domain_name` (optional, required when `codearts_token` is empty)
+- `iam_project_name` (optional, required when `codearts_token` is empty)
+
+### Task
+
+- `project_id` (required)
+- `project_name` (required)
+- `repo_url` (required)
+- `branch` (required, default: `main`)
+- `task_name` (required)
+- `repo_type` (required, default: `GitHub`)
+- `rule_language` (required, default: `Java`)
+- `auth_id` (optional)
+- `auth_type` (optional)
+- `run_ref` (optional): `pull` or `merge_request`
+- `timeout_seconds` (optional, default: `1800`)
+- `poll_interval_seconds` (optional, default: `15`)
+- `include_status_ids` (optional, default: `0`)
+- `max_defects` (optional, default: `500`)
+- `fail_on_job_failure` (optional, default: `false`)
+
+### Report upload
+
+- `report_repo` (optional, default: `Jo-joker/maven-demo`)
+- `report_dir` (optional, default: `analyze`)
+- `report_branch` (optional, default: target repo default branch)
+- `report_commit_message` (optional, default: `docs: add CodeArts Check analysis report`)
+- `github_token` (required): token with `contents:write` on target repository
+
+## Outputs
+
+- `task_id`
+- `exec_id`
+- `job_status`
+- `report_path`
+- `report_url`
+- `report_sha`
+
+## Example workflow
+
+```yaml
+name: codearts-check
+
+on:
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Run CodeArts Check and upload report
+        uses: Jo-joker/codearts-check-report-action@main
+        with:
+          codearts_endpoint: ${{ secrets.CODEARTS_ENDPOINT }}
+          codearts_token: ${{ secrets.CODEARTS_TOKEN }}
+          # If CODEARTS_TOKEN is not provided, configure IAM fields instead:
+          # iam_endpoint: https://iam.myhuaweicloud.com
+          # iam_username: ${{ secrets.HW_IAM_USERNAME }}
+          # iam_password: ${{ secrets.HW_IAM_PASSWORD }}
+          # iam_domain_name: ${{ secrets.HW_IAM_DOMAIN }}
+          # iam_project_name: ${{ secrets.HW_IAM_PROJECT }}
+          project_id: ${{ secrets.CODEARTS_PROJECT_ID }}
+          project_name: ${{ secrets.CODEARTS_PROJECT_NAME }}
+          repo_url: ${{ secrets.CODEARTS_REPO_URL }}
+          branch: main
+          task_name: maven-demo-main-check
+          repo_type: GitHub
+          rule_language: Java
+          report_repo: Jo-joker/maven-demo
+          report_dir: analyze
+          github_token: ${{ secrets.REPORT_REPO_TOKEN }}
+```
+
+## Notes
+
+- Creating a task on every run may fail if your project enforces unique task names. Use dynamic `task_name` or adjust your task management strategy.
+- Ensure the CodeArts account has permissions to create and execute tasks and read reports.
+- Ensure `github_token` can write to the target report repository.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ jobs:
           github_token: ${{ secrets.REPORT_REPO_TOKEN }}
 ```
 
+This repository also includes a ready-to-use example file:
+
+- `.github/workflows/codearts-check.yml`
+
 ## Notes
 
 - Creating a task on every run may fail if your project enforces unique task names. Use dynamic `task_name` or adjust your task management strategy.

--- a/action.yaml
+++ b/action.yaml
@@ -1,19 +1,120 @@
+name: "CodeArts Check Analyzer"
+description: "Create and run a Huawei Cloud CodeArts Check task, then publish a Markdown report to another GitHub repository."
+author: "Jo-joker"
 
-能描述；
-背景：为了帮助用户更直观的了解部署模板的内容，建议在选中某一个模板之后在模板右侧的空白处对模板的内容或者功能进行预览，帮助用户快速了解模板的功能。
+inputs:
+  codearts_endpoint:
+    description: "CodeArts Check API endpoint, for example https://codeartscheck.cn-north-4.myhuaweicloud.com"
+    required: true
+  codearts_token:
+    description: "Huawei Cloud X-Auth-Token. If empty, IAM username/password flow is used."
+    required: false
+  iam_endpoint:
+    description: "IAM endpoint used to obtain X-Auth-Token. Can be full URL or host root. Example: https://iam.myhuaweicloud.com"
+    required: false
+    default: "https://iam.myhuaweicloud.com"
+  iam_username:
+    description: "IAM username (used only when codearts_token is not provided)"
+    required: false
+  iam_password:
+    description: "IAM password (used only when codearts_token is not provided)"
+    required: false
+  iam_domain_name:
+    description: "IAM account/domain name (used only when codearts_token is not provided)"
+    required: false
+  iam_project_name:
+    description: "IAM project name used for token scope (used only when codearts_token is not provided)"
+    required: false
+  project_id:
+    description: "CodeArts project ID"
+    required: true
+  project_name:
+    description: "CodeArts project name"
+    required: true
+  repo_url:
+    description: "Code repository URL configured in CodeArts Check task"
+    required: true
+  branch:
+    description: "Branch to check"
+    required: true
+    default: "main"
+  task_name:
+    description: "CodeArts Check task name"
+    required: true
+  repo_type:
+    description: "Repository type: DevCloud, Gitee, GitHub, GitPub, gitcode, gitlab, self_gitlab, tfs_git, bitbucket"
+    required: true
+    default: "GitHub"
+  rule_language:
+    description: "Language field in rule_sets (for example Java, Python, C++)"
+    required: true
+    default: "Java"
+  auth_id:
+    description: "Code source endpoint authId for non-DevCloud repos (optional)"
+    required: false
+  auth_type:
+    description: "Authorization type for non-DevCloud repos (optional)"
+    required: false
+  run_ref:
+    description: "Optional run ref mode: pull or merge_request"
+    required: false
+  timeout_seconds:
+    description: "Max wait time for task completion"
+    required: false
+    default: "1800"
+  poll_interval_seconds:
+    description: "Polling interval in seconds for execution status"
+    required: false
+    default: "15"
+  include_status_ids:
+    description: "Defect status filter for defects detail API. 0=pending,1=resolved,2=ignored (comma-separated allowed)"
+    required: false
+    default: "0"
+  max_defects:
+    description: "Maximum number of defects to include in report"
+    required: false
+    default: "500"
+  report_repo:
+    description: "Target report repository in owner/repo format"
+    required: false
+    default: "Jo-joker/maven-demo"
+  report_dir:
+    description: "Directory in target repo where report is uploaded"
+    required: false
+    default: "analyze"
+  report_branch:
+    description: "Optional target branch in report repository"
+    required: false
+  report_commit_message:
+    description: "Commit message for uploading report"
+    required: false
+    default: "docs: add CodeArts Check analysis report"
+  github_token:
+    description: "GitHub token with contents:write permission on target report repo"
+    required: true
+  fail_on_job_failure:
+    description: "If true, fail action when job status is failed or aborted"
+    required: false
+    default: "false"
 
-需求：
-1、模板在被选中后才展示预览内容；
+outputs:
+  task_id:
+    description: "Created CodeArts task ID"
+  exec_id:
+    description: "CodeArts execution record ID"
+  job_status:
+    description: "Execution status: quering/running/success/failed/aborted"
+  report_path:
+    description: "Uploaded report path in report repository"
+  report_url:
+    description: "HTML URL of uploaded report file"
+  report_sha:
+    description: "Git blob SHA of uploaded report content"
 
-2、预览内容主要以流程图的方式展示给用户，表示模板中的每一作用。e.g. tomcat模板，预览中的内容跟模板实际中的部署步骤保持一致，以流程图展示。
+runs:
+  using: "node20"
+  main: "index.js"
 
-3、对于由单一的部署步骤构成的模板，已部署步骤中的内容进行介绍。e.g. Kubernetes部署为例。以用户需要输入的集“群->命名空间->Manifest配置文件”等对应到流程图中。
-
-说明：
-1、一个模板中包含的部署步骤数通常在10个以内。最高不多余20个。
-2、预览的风格是否可以做成组件形式的标准格式，后续我们有新的模
-
-
-
-
-
+branding:
+  icon: "check-circle"
+  color: "blue"

--- a/index.js
+++ b/index.js
@@ -1,0 +1,653 @@
+const core = {
+  getInput(name, options = {}) {
+    const key = `INPUT_${String(name).replace(/ /g, "_").toUpperCase()}`;
+    const value = process.env[key] ?? "";
+    if (options.required && !value.trim()) {
+      throw new Error(`Input required and not supplied: ${name}`);
+    }
+    return value.trim();
+  },
+  setOutput(name, value) {
+    const line = `${name}=${escapeCommandValue(value)}`;
+    const outputFile = process.env.GITHUB_OUTPUT;
+    if (outputFile) {
+      require("node:fs").appendFileSync(outputFile, `${line}\n`, "utf8");
+      return;
+    }
+    process.stdout.write(`::set-output name=${name}::${escapeCommandValue(value)}\n`);
+  },
+  setFailed(message) {
+    process.exitCode = 1;
+    process.stdout.write(`::error::${escapeCommandValue(message)}\n`);
+  },
+  info(message) {
+    process.stdout.write(`${String(message)}\n`);
+  },
+  warning(message) {
+    process.stdout.write(`::warning::${escapeCommandValue(message)}\n`);
+  },
+};
+
+function escapeCommandValue(value) {
+  return String(value ?? "")
+    .replace(/%/g, "%25")
+    .replace(/\r/g, "%0D")
+    .replace(/\n/g, "%0A");
+}
+
+function normalizeEndpoint(endpoint) {
+  return endpoint.replace(/\/+$/, "");
+}
+
+function asBoolean(value, defaultValue = false) {
+  if (value === undefined || value === null || value === "") {
+    return defaultValue;
+  }
+  return String(value).trim().toLowerCase() === "true";
+}
+
+function asInteger(value, fallback) {
+  const parsed = Number.parseInt(String(value), 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function encodeBase64(str) {
+  return Buffer.from(str, "utf8").toString("base64");
+}
+
+function decodeBase64(str) {
+  return Buffer.from(str, "base64").toString("utf8");
+}
+
+async function requestJson(url, options = {}, expectedStatuses = [200]) {
+  const response = await fetch(url, options);
+  const text = await response.text();
+  let body = {};
+  if (text) {
+    try {
+      body = JSON.parse(text);
+    } catch (error) {
+      throw new Error(`Failed to parse JSON from ${url}: ${error.message}. Raw body: ${text}`);
+    }
+  }
+
+  if (!expectedStatuses.includes(response.status)) {
+    const errorCode = body.error_code ? ` (${body.error_code})` : "";
+    const errorMsg = body.error_msg ? `: ${body.error_msg}` : "";
+    throw new Error(`Request failed ${response.status} ${response.statusText}${errorCode}${errorMsg} on ${url}`);
+  }
+
+  return {
+    status: response.status,
+    headers: response.headers,
+    body,
+  };
+}
+
+async function obtainIamToken(iamEndpoint, username, password, domainName, projectName) {
+  const endpoint = normalizeEndpoint(iamEndpoint);
+  const url = `${endpoint}/v3/auth/tokens`;
+
+  const payload = {
+    auth: {
+      identity: {
+        methods: ["password"],
+        password: {
+          user: {
+            name: username,
+            password,
+            domain: {
+              name: domainName,
+            },
+          },
+        },
+      },
+      scope: {
+        project: {
+          name: projectName,
+        },
+      },
+    },
+  };
+
+  const response = await requestJson(
+    url,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    },
+    [201]
+  );
+
+  const token = response.headers.get("x-subject-token");
+  if (!token) {
+    throw new Error("IAM token request succeeded but x-subject-token header is missing.");
+  }
+  return token;
+}
+
+function buildTaskPayload(inputs) {
+  const configTemplate = {
+    repo_type: inputs.repoType,
+    branch: inputs.branch,
+    rule_sets: [
+      {
+        language: inputs.ruleLanguage,
+      },
+    ],
+    project_id: inputs.projectId,
+    project_name: inputs.projectName,
+  };
+
+  if (inputs.authId) {
+    configTemplate.authId = inputs.authId;
+  }
+  if (inputs.authType) {
+    configTemplate.authType = inputs.authType;
+  }
+
+  return {
+    repo_url: inputs.repoUrl,
+    branch: inputs.branch,
+    name: inputs.taskName,
+    config_template: configTemplate,
+    project_id: inputs.projectId,
+    project_name: inputs.projectName,
+  };
+}
+
+async function createTask(baseEndpoint, token, inputs) {
+  const url = `${baseEndpoint}/v3/task`;
+  const payload = buildTaskPayload(inputs);
+  const response = await requestJson(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Auth-Token": token,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const taskId = response.body?.result?.id;
+  if (!taskId) {
+    throw new Error(`Create task succeeded but task id not found. Response: ${JSON.stringify(response.body)}`);
+  }
+  return taskId;
+}
+
+async function runTask(baseEndpoint, token, taskId, runRef) {
+  const url = `${baseEndpoint}/v2/tasks/${encodeURIComponent(taskId)}/run`;
+  const payload = {};
+  if (runRef) {
+    payload.ref = runRef;
+  }
+
+  const response = await requestJson(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Auth-Token": token,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const execId = response.body?.exec_id;
+  if (!execId) {
+    throw new Error(`Run task succeeded but exec_id not found. Response: ${JSON.stringify(response.body)}`);
+  }
+  return execId;
+}
+
+async function getJobs(baseEndpoint, token, taskId, page = 1, pageSize = 200) {
+  const url = `${baseEndpoint}/v4/tasks/${encodeURIComponent(taskId)}/jobs?page=${page}&page_size=${pageSize}`;
+  const response = await requestJson(url, {
+    headers: {
+      "X-Auth-Token": token,
+    },
+  });
+  return response.body;
+}
+
+function mapJobStatusToResult(status) {
+  if (status === "success") {
+    return "success";
+  }
+  if (status === "failed" || status === "aborted") {
+    return "failure";
+  }
+  return null;
+}
+
+async function waitForJobCompletion(baseEndpoint, token, taskId, execId, timeoutSeconds, pollIntervalSeconds) {
+  const timeoutMs = timeoutSeconds * 1000;
+  const intervalMs = pollIntervalSeconds * 1000;
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const jobsData = await getJobs(baseEndpoint, token, taskId);
+    const jobs = Array.isArray(jobsData.data) ? jobsData.data : [];
+    const matched = jobs.find((job) => job.id === execId);
+
+    if (matched) {
+      core.info(`Current job status: ${matched.status}`);
+      const result = mapJobStatusToResult(matched.status);
+      if (result) {
+        return matched;
+      }
+    } else {
+      core.info("Execution record not visible yet, continue polling.");
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  throw new Error(`Timed out after ${timeoutSeconds}s waiting for execution ${execId}.`);
+}
+
+async function getSummary(baseEndpoint, token, taskId, execId) {
+  const url = `${baseEndpoint}/v2/tasks/${encodeURIComponent(taskId)}/defects-summary?job_id=${encodeURIComponent(execId)}`;
+  const response = await requestJson(url, {
+    headers: {
+      "X-Auth-Token": token,
+    },
+  });
+  return response.body;
+}
+
+async function getDefectsPage(baseEndpoint, token, taskId, options) {
+  const params = new URLSearchParams();
+  params.set("offset", String(options.offset));
+  params.set("limit", String(options.limit));
+  if (options.statusIds) {
+    params.set("status_ids", options.statusIds);
+  }
+  if (options.severity) {
+    params.set("severity", options.severity);
+  }
+
+  const url = `${baseEndpoint}/v2/tasks/${encodeURIComponent(taskId)}/defects-detail?${params.toString()}`;
+  const response = await requestJson(url, {
+    headers: {
+      "X-Auth-Token": token,
+    },
+  });
+  return response.body;
+}
+
+function severityName(level) {
+  switch (String(level)) {
+    case "0":
+      return "Critical";
+    case "1":
+      return "Major";
+    case "2":
+      return "Minor";
+    case "3":
+      return "Suggestion";
+    default:
+      return "Unknown";
+  }
+}
+
+function statusName(status) {
+  switch (String(status)) {
+    case "0":
+      return "Pending";
+    case "1":
+      return "Resolved";
+    case "2":
+      return "Ignored";
+    default:
+      return "Unknown";
+  }
+}
+
+function escapeMdCell(value) {
+  return String(value ?? "").replace(/\|/g, "\\|").replace(/\n/g, " ");
+}
+
+function utcTimestampCompact(date = new Date()) {
+  const pad = (num) => String(num).padStart(2, "0");
+  return `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}-${pad(date.getUTCHours())}${pad(
+    date.getUTCMinutes()
+  )}${pad(date.getUTCSeconds())}`;
+}
+
+function buildMarkdownReport(context) {
+  const {
+    taskId,
+    execId,
+    taskName,
+    branch,
+    repoUrl,
+    ruleLanguage,
+    projectId,
+    projectName,
+    summary,
+    defects,
+    generatedAt,
+    runUrl,
+    job,
+  } = context;
+
+  const lines = [];
+  lines.push("# CodeArts Check Analysis Report");
+  lines.push("");
+  lines.push(`- Generated At (UTC): ${generatedAt}`);
+  lines.push(`- GitHub Run: ${runUrl}`);
+  lines.push(`- Project: ${projectName} (${projectId})`);
+  lines.push(`- Task Name: ${taskName}`);
+  lines.push(`- Task ID: ${taskId}`);
+  lines.push(`- Execution ID: ${execId}`);
+  lines.push(`- Repository: ${repoUrl}`);
+  lines.push(`- Branch: ${branch}`);
+  lines.push(`- Rule Language: ${ruleLanguage}`);
+  lines.push(`- Execution Status: ${job.status}`);
+  lines.push(`- Execution Start: ${job.startTime || "N/A"}`);
+  lines.push(`- Execution Finish: ${job.finishTime || "N/A"}`);
+  lines.push("");
+  lines.push("## Summary");
+  lines.push("");
+  lines.push("| Metric | Value |");
+  lines.push("| --- | --- |");
+  lines.push(`| issue_count | ${summary.issue_count ?? "N/A"} |`);
+  lines.push(`| new_count | ${summary.new_count ?? "N/A"} |`);
+  lines.push(`| solve_count | ${summary.solve_count ?? "N/A"} |`);
+  lines.push(`| critical_count | ${summary.critical_count ?? "N/A"} |`);
+  lines.push(`| major_count | ${summary.major_count ?? "N/A"} |`);
+  lines.push(`| minor_count | ${summary.minor_count ?? "N/A"} |`);
+  lines.push(`| suggestion_count | ${summary.suggestion_count ?? "N/A"} |`);
+  lines.push(`| code_line | ${summary.code_line ?? "N/A"} |`);
+  lines.push(`| code_line_total | ${summary.code_line_total ?? "N/A"} |`);
+  lines.push(`| duplication_ratio | ${summary.duplication_ratio ?? "N/A"} |`);
+  lines.push(`| file_duplication_ratio | ${summary.file_duplication_ratio ?? "N/A"} |`);
+  lines.push(`| complexity_count | ${summary.complexity_count ?? "N/A"} |`);
+  lines.push(`| risk_coefficient | ${summary.risk_coefficient ?? "N/A"} |`);
+  lines.push(`| review_result | ${summary.review_result ?? "N/A"} |`);
+  lines.push(`| is_access | ${summary.is_access ?? "N/A"} |`);
+  lines.push("");
+  lines.push("## Defects");
+  lines.push("");
+  lines.push(`Total defects fetched: **${defects.length}**`);
+  lines.push("");
+
+  if (defects.length === 0) {
+    lines.push("No defects matched the selected filter.");
+    lines.push("");
+  } else {
+    lines.push("| # | Severity | Status | Rule | File | Line | Description |");
+    lines.push("| --- | --- | --- | --- | --- | --- | --- |");
+    defects.forEach((defect, index) => {
+      lines.push(
+        `| ${index + 1} | ${severityName(defect.defect_level)} | ${statusName(defect.defect_status)} | ${escapeMdCell(
+          defect.rule_name || defect.defect_checker_name
+        )} | ${escapeMdCell(defect.file_path)} | ${escapeMdCell(defect.line_number)} | ${escapeMdCell(defect.defect_content)} |`
+      );
+    });
+    lines.push("");
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function sanitizePathSegment(value) {
+  return String(value)
+    .trim()
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 80);
+}
+
+function parseOwnerRepo(ownerRepo) {
+  const parts = String(ownerRepo).split("/");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    throw new Error(`Invalid owner/repo format: ${ownerRepo}`);
+  }
+  return {
+    owner: parts[0],
+    repo: parts[1],
+  };
+}
+
+async function githubRequestJson(url, token, options = {}, expectedStatuses = [200]) {
+  return requestJson(
+    url,
+    {
+      ...options,
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+        ...(options.headers || {}),
+      },
+    },
+    expectedStatuses
+  );
+}
+
+async function getDefaultBranch(githubToken, owner, repo) {
+  const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+  const response = await githubRequestJson(url, githubToken);
+  const branch = response.body?.default_branch;
+  if (!branch) {
+    throw new Error(`Cannot determine default branch for ${owner}/${repo}`);
+  }
+  return branch;
+}
+
+async function getFileShaIfExists(githubToken, owner, repo, path, branch) {
+  const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${path}?ref=${encodeURIComponent(
+    branch
+  )}`;
+
+  try {
+    const response = await githubRequestJson(url, githubToken);
+    return response.body?.sha;
+  } catch (error) {
+    if (error.message.includes("404")) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function putFile(githubToken, owner, repo, path, branch, message, content, sha) {
+  const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${path}`;
+  const payload = {
+    message,
+    content: encodeBase64(content),
+    branch,
+  };
+  if (sha) {
+    payload.sha = sha;
+  }
+
+  const response = await githubRequestJson(
+    url,
+    githubToken,
+    {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    },
+    [200, 201]
+  );
+
+  const contentInfo = response.body?.content;
+  if (!contentInfo?.sha) {
+    throw new Error(`GitHub upload succeeded but content SHA missing. Response: ${JSON.stringify(response.body)}`);
+  }
+
+  return {
+    sha: contentInfo.sha,
+    path: contentInfo.path,
+    htmlUrl: contentInfo.html_url,
+    downloadUrl: contentInfo.download_url,
+    encodedContent: contentInfo.content,
+  };
+}
+
+async function fetchDefects(baseEndpoint, token, taskId, statusIds, maxDefects) {
+  const defects = [];
+  let offset = 0;
+  const pageLimit = 200;
+
+  while (defects.length < maxDefects) {
+    const limit = Math.min(pageLimit, maxDefects - defects.length);
+    const page = await getDefectsPage(baseEndpoint, token, taskId, {
+      offset,
+      limit,
+      statusIds,
+    });
+
+    const pageDefects = Array.isArray(page.defects) ? page.defects : [];
+    defects.push(...pageDefects);
+    offset += limit;
+
+    if (pageDefects.length === 0 || defects.length >= (page.total ?? Number.MAX_SAFE_INTEGER)) {
+      break;
+    }
+  }
+
+  return defects.slice(0, maxDefects);
+}
+
+async function run() {
+  try {
+    const inputs = {
+      codeartsEndpoint: normalizeEndpoint(core.getInput("codearts_endpoint", { required: true })),
+      codeartsToken: core.getInput("codearts_token"),
+      iamEndpoint: core.getInput("iam_endpoint"),
+      iamUsername: core.getInput("iam_username"),
+      iamPassword: core.getInput("iam_password"),
+      iamDomainName: core.getInput("iam_domain_name"),
+      iamProjectName: core.getInput("iam_project_name"),
+      projectId: core.getInput("project_id", { required: true }),
+      projectName: core.getInput("project_name", { required: true }),
+      repoUrl: core.getInput("repo_url", { required: true }),
+      branch: core.getInput("branch", { required: true }),
+      taskName: core.getInput("task_name", { required: true }),
+      repoType: core.getInput("repo_type", { required: true }),
+      ruleLanguage: core.getInput("rule_language", { required: true }),
+      authId: core.getInput("auth_id"),
+      authType: core.getInput("auth_type"),
+      runRef: core.getInput("run_ref"),
+      timeoutSeconds: asInteger(core.getInput("timeout_seconds"), 1800),
+      pollIntervalSeconds: asInteger(core.getInput("poll_interval_seconds"), 15),
+      includeStatusIds: core.getInput("include_status_ids"),
+      maxDefects: asInteger(core.getInput("max_defects"), 500),
+      reportRepo: core.getInput("report_repo"),
+      reportDir: core.getInput("report_dir"),
+      reportBranch: core.getInput("report_branch"),
+      reportCommitMessage: core.getInput("report_commit_message"),
+      githubToken: core.getInput("github_token", { required: true }),
+      failOnJobFailure: asBoolean(core.getInput("fail_on_job_failure"), false),
+    };
+
+    let token = inputs.codeartsToken;
+    if (!token) {
+      if (!inputs.iamUsername || !inputs.iamPassword || !inputs.iamDomainName || !inputs.iamProjectName) {
+        throw new Error(
+          "codearts_token is empty. iam_username, iam_password, iam_domain_name, and iam_project_name are required for IAM token flow."
+        );
+      }
+      core.info("Obtaining CodeArts token from IAM.");
+      token = await obtainIamToken(
+        inputs.iamEndpoint,
+        inputs.iamUsername,
+        inputs.iamPassword,
+        inputs.iamDomainName,
+        inputs.iamProjectName
+      );
+    }
+
+    core.info("Creating CodeArts Check task.");
+    const taskId = await createTask(inputs.codeartsEndpoint, token, inputs);
+    core.setOutput("task_id", taskId);
+    core.info(`Task created: ${taskId}`);
+
+    core.info("Running task.");
+    const execId = await runTask(inputs.codeartsEndpoint, token, taskId, inputs.runRef);
+    core.setOutput("exec_id", execId);
+    core.info(`Execution started: ${execId}`);
+
+    core.info("Polling execution status.");
+    const job = await waitForJobCompletion(
+      inputs.codeartsEndpoint,
+      token,
+      taskId,
+      execId,
+      inputs.timeoutSeconds,
+      inputs.pollIntervalSeconds
+    );
+    core.setOutput("job_status", job.status);
+    core.info(`Execution completed with status: ${job.status}`);
+
+    core.info("Querying summary and defects.");
+    const summary = await getSummary(inputs.codeartsEndpoint, token, taskId, execId);
+    const defects = await fetchDefects(inputs.codeartsEndpoint, token, taskId, inputs.includeStatusIds, inputs.maxDefects);
+    core.info(`Fetched defects: ${defects.length}`);
+
+    const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+    const markdown = buildMarkdownReport({
+      taskId,
+      execId,
+      taskName: inputs.taskName,
+      branch: inputs.branch,
+      repoUrl: inputs.repoUrl,
+      ruleLanguage: inputs.ruleLanguage,
+      projectId: inputs.projectId,
+      projectName: inputs.projectName,
+      summary,
+      defects,
+      generatedAt: new Date().toISOString(),
+      runUrl,
+      job,
+    });
+
+    const { owner, repo } = parseOwnerRepo(inputs.reportRepo);
+    const reportBranch = inputs.reportBranch || (await getDefaultBranch(inputs.githubToken, owner, repo));
+    const reportFileName = `${utcTimestampCompact()}-${sanitizePathSegment(inputs.taskName)}-${sanitizePathSegment(execId)}.md`;
+    const reportPath = `${inputs.reportDir.replace(/^\/+|\/+$/g, "")}/${reportFileName}`;
+
+    core.info(`Uploading report to ${owner}/${repo}:${reportPath} on branch ${reportBranch}`);
+    const existingSha = await getFileShaIfExists(inputs.githubToken, owner, repo, reportPath, reportBranch);
+    const uploadResult = await putFile(
+      inputs.githubToken,
+      owner,
+      repo,
+      reportPath,
+      reportBranch,
+      `${inputs.reportCommitMessage} [task:${taskId} exec:${execId}]`,
+      markdown,
+      existingSha
+    );
+
+    // Verify write by comparing decoded response content when available.
+    if (uploadResult.encodedContent) {
+      const decoded = decodeBase64(uploadResult.encodedContent.replace(/\n/g, ""));
+      if (decoded.trim() !== markdown.trim()) {
+        core.warning("Uploaded content decoded from GitHub response does not exactly match local markdown.");
+      }
+    }
+
+    core.setOutput("report_path", uploadResult.path);
+    core.setOutput("report_url", uploadResult.htmlUrl || uploadResult.downloadUrl || "");
+    core.setOutput("report_sha", uploadResult.sha);
+    core.info(`Report uploaded successfully: ${uploadResult.path}`);
+
+    if (inputs.failOnJobFailure && (job.status === "failed" || job.status === "aborted")) {
+      core.setFailed(`CodeArts Check execution ended in status ${job.status}. Report was still uploaded.`);
+    }
+  } catch (error) {
+    core.setFailed(error instanceof Error ? error.message : String(error));
+  }
+}
+
+run();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- implement a JavaScript GitHub Action to integrate with Huawei Cloud CodeArts Check
- create a CodeArts Check task, run it, poll execution status, and fetch summary/defect results
- generate a Markdown analysis report and upload it to a target GitHub repository directory (default `Jo-joker/maven-demo/analyze`)
- document all required inputs, outputs, and a full workflow example
- add a ready-to-use workflow file at `.github/workflows/codearts-check.yml`

## Implementation details
- `action.yaml`
  - defines all inputs for CodeArts endpoint/auth, task configuration, polling behavior, report target repo/dir, and upload token
  - exports outputs (`task_id`, `exec_id`, `job_status`, `report_path`, `report_url`, `report_sha`)
- `index.js`
  - implements CodeArts API flow:
    1. obtain IAM token (optional) or use provided `codearts_token`
    2. `POST /v3/task` to create check task
    3. `POST /v2/tasks/{task_id}/run` to execute check task
    4. poll `GET /v4/tasks/{task_id}/jobs` until matched `exec_id` reaches terminal status
    5. read summary via `GET /v2/tasks/{task_id}/defects-summary?job_id={exec_id}`
    6. paginate defects via `GET /v2/tasks/{task_id}/defects-detail`
  - renders a Markdown report with summary metrics and defect table
  - uploads report to target repo using GitHub Contents API
- `.github/workflows/codearts-check.yml`
  - provides a ready-to-use CI workflow using `uses: ./`
  - includes required secrets placeholders for CodeArts/IAM and report upload token
- `README.md`
  - replaced placeholder content with usage documentation and workflow sample
  - references the built-in workflow example file

## Notes
- action creates a new task each run; use unique `task_name` if your CodeArts project enforces uniqueness
- uploading to another repo requires `github_token` with `contents:write` on that target repo
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93967fb5-277d-4519-8e5c-f20a03390ea7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93967fb5-277d-4519-8e5c-f20a03390ea7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

